### PR TITLE
Adding the transaction "payload" field to the PSQL structure

### DIFF
--- a/app/db/updatepg.sql
+++ b/app/db/updatepg.sql
@@ -12,7 +12,7 @@ ALTER TABLE Transaction ADD COLUMN creator_msp_id character varying(128) DEFAULT
 ALTER TABLE Transaction ADD COLUMN endorser_msp_id character varying(800) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN chaincode_id character varying(256) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN type character varying(128) DEFAULT NULL;
-ALTER TABLE Transaction ADD COLUMN payload charactere varying(8000) DEFAULT NULL;
+ALTER TABLE Transaction ADD COLUMN payload character varying(8000) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN read_set  json default NULL;
 ALTER TABLE Transaction ADD COLUMN write_set  json default NULL;
 

--- a/app/db/updatepg.sql
+++ b/app/db/updatepg.sql
@@ -12,6 +12,7 @@ ALTER TABLE Transaction ADD COLUMN creator_msp_id character varying(128) DEFAULT
 ALTER TABLE Transaction ADD COLUMN endorser_msp_id character varying(800) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN chaincode_id character varying(256) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN type character varying(128) DEFAULT NULL;
+ALTER TABLE Transaction ADD COLUMN payload charactere varying(8000) DEFAULT NULL;
 ALTER TABLE Transaction ADD COLUMN read_set  json default NULL;
 ALTER TABLE Transaction ADD COLUMN write_set  json default NULL;
 


### PR DESCRIPTION
### Ref: 
#1 

### Description:
Adding `payload` to the PostgreSQL is going to help us fetch the `payload` information from the explorer.

### Blocking:
Yes. 

### Documentation:
Not required at the moment.

