### PR TITLE
A page to display the UUIDs received and the response that was sent

### DIFF
--- a/app/db/explorerpg.sql
+++ b/app/db/explorerpg.sql
@@ -163,4 +163,15 @@ ALTER TABLE write_lock owner to diid;
 
 ALTER SEQUENCE write_lock_write_lock_seq restart WITH 2;
 
+DROP TABLE IF EXISTS uuid;
+
+CREATE TABLE uuid (
+    id                  varchar(64)                 PRIMARY KEY,
+    reqcreatedt         timestamp                   DEFAULT NULL,
+    respayload          character varying(1000)     DEFAULT NULL,
+    rescreatedt         timestamp                   DEFAULT NULL
+);
+
+ALTER TABLE uuid owner to diid;
+
 GRANT SELECT, INSERT, UPDATE,DELETE ON ALL TABLES IN SCHEMA PUBLIC to diid;

--- a/app/db/pgservice.js
+++ b/app/db/pgservice.js
@@ -85,8 +85,8 @@ function saveRow(tablename, columnValues) {
         var updatesqlparmstr = updatesqlcolumn.join(',')
         var updatesqlflagstr = updatesqlflag.join(',')
         var addSql = `INSERT INTO ${tablename}  ( ${updatesqlparmstr} ) VALUES( ${updatesqlflagstr}  ) RETURNING *;`;
-        logger.debug(`Insert sql is ${addSql}`)
-        console.log(`Insert sql is ${addSql}`)
+        // logger.debug(`Insert sql is ${addSql}`)
+
         client.query(addSql, addSqlParams, (err, res) => {
 
             if (err) {
@@ -96,7 +96,7 @@ function saveRow(tablename, columnValues) {
             }
 
             logger.debug('--------------------------INSERT----------------------------');
-            console.log('INSERT ID:', res.rows[0].id);
+            logger.debug('INSERT ID:', res.rows[0].id);
             logger.debug('-----------------------------------------------------------------\n\n');
 
             resolve(res.rows[0].id)
@@ -166,8 +166,7 @@ function updateRowByPk(tablename, columnAndValue, pkName, pkValue) {
             }
 
             logger.debug('--------------------------UPDATE----------------------------');
-            //logger.debug(' update result :', result.affectedRows);
-            //console.log(res);
+            logger.debug(' update result :', result.affectedRows);
             logger.debug('-----------------------------------------------------------------\n\n');
 
             resolve(res.rows)
@@ -199,42 +198,31 @@ function updateRow(tablename, columnAndValue, condition) {
         var addSqlParams = []
         var updateParms = []
 
-        var updateparm = " set 1=1 "
-
+        var updateparm = ""
 
         Object.keys(columnAndValue).forEach((k) => {
-
             let v = columnAndValue[k]
 
             addSqlParams.push(v)
-            //updateparm = updateparm + ` ,${k}=? `
-            updateParms.push(`${k} = ?`)
-
+            updateParms.push(` ${k} = '${v}' `)
         })
+        var updateParmsStr = updateParms.join(',')
 
-        var updatewhereparm = " (1=1)  "
-
+        var updatewhereparm = " (1=1) "
 
         Object.keys(condition).forEach((k) => {
-
             let v = condition[k]
 
             addSqlParams.push(v)
-            updatewhereparm = updatewhereparm + ` and ${k}=? `
-
+            updatewhereparm = updatewhereparm + ` and ${k} = '?' `
         })
-
-
-        var updateParmsStr = updateParms.join(',')
 
         var addSql = ` UPDATE ${tablename} set ${updateParmsStr} WHERE ${updatewhereparm} RETURNING * `;
 
-        logger.debug(`update sql is ${addSql}`)
-        console.log(`update sql is ${addSql}`)
-        client.query(addSql, addSqlParams, (err, res) => {
+        client.query(addSql, [], (err, res) => {
 
             if (err) {
-                logger.error('[INSERT ERROR] - ', err.message);
+                logger.error('[UPDATE ERROR] - ', err.message);
                 reject(err)
             }
 
@@ -261,6 +249,7 @@ function updateBySql(updateSql) {
         logger.debug(`update sql is :  ${updateSql}`)
 
         client.query(updateSql, [], (err, res) => {
+
 
             if (err) {
                 logger.error('[INSERT ERROR] - ', err.message);
@@ -457,7 +446,6 @@ function getRowsBySQlQuery(sql) {
 
     return new Promise(function (resolve, reject) {
         client.query(sql, (err, res) => {
-
             if (err) {
                 reject(err)
             }
@@ -488,7 +476,6 @@ function getRowsBySQlNoCondtion(sqlcharacter, limit) {
         var sql = `${sqlcharacter} ${limit}`
 
         client.query(sqlcharacter, (err, res) => {
-
             if (err) {
                 reject(err)
             }
@@ -636,5 +623,3 @@ exports.getSQL2Map4Arr = getSQL2Map4Arr
 
 exports.openconnection = openconnection
 exports.closeconnection = closeconnection
-
-

--- a/app/helper.js
+++ b/app/helper.js
@@ -39,6 +39,17 @@ var getLogger = function (moduleName) {
 	return logger;
 };
 
+var getUUIDFromPayload = function(strPayload) {
+	let uuid;
+	try {
+		var parsedPayload = JSON.stringify(strPayload).replace(/\\n/g, "").replace(/\\/g, "").replace("\"{", "{").replace("}\"", "}")
+		uuid = JSON.parse(parsedPayload).uuid;
+	} catch(err) {
+		uuid = "";
+	}
+	return uuid;
+}
 
 exports.getLogger = getLogger;
 exports.readAllFiles = readAllFiles;
+exports.getUUIDFromPayload = getUUIDFromPayload;

--- a/app/models/transactions.js
+++ b/app/models/transactions.js
@@ -2,9 +2,6 @@
     SPDX-License-Identifier: Apache-2.0
 */
 
-var co = require('co')
-var helper = require('../helper.js');
-var logger = helper.getLogger('transactions');
 var sql = require('../db/pgservice.js');
 
 function getTransactionByID(channelName, txhash) {

--- a/app/models/uuids.js
+++ b/app/models/uuids.js
@@ -1,8 +1,8 @@
 var sql = require('../db/pgservice.js');
 
 function getUUIDStatusList(channelName) {
-    let sqlUUIDList = `selecct * from UUID`;
-    return sql.getRowsBySQlQuery(sqlUUIDList);
+    let sqlUUIDList = `select * from UUID`;
+    return sql.getRowsBySQlNoCondtion(sqlUUIDList);
 }
 
 function getUUIDStatusRow(channelName) {
@@ -11,5 +11,5 @@ function getUUIDStatusRow(channelName) {
 }
 
 
-exports.getUUIDStatusList = getUUIDStatusList
-exports.getUUIDStatusRow = getUUIDStatusRow
+exports.getUUIDStatusList = getUUIDStatusList;
+exports.getUUIDStatusRow = getUUIDStatusRow;

--- a/app/models/uuids.js
+++ b/app/models/uuids.js
@@ -1,0 +1,15 @@
+var sql = require('../db/pgservice.js');
+
+function getUUIDStatusList(channelName) {
+    let sqlUUIDList = `selecct * from UUID`;
+    return sql.getRowsBySQlQuery(sqlUUIDList);
+}
+
+function getUUIDStatusRow(channelName) {
+    let sqlUUID = `select * from UUID where reqcreatedt = (select MAX(reqcreatedt) from UUID) limit 1`;
+    return sql.getRowByPkOne(sqlUUID)
+}
+
+
+exports.getUUIDStatusList = getUUIDStatusList
+exports.getUUIDStatusRow = getUUIDStatusRow

--- a/app/service/blockscanner.js
+++ b/app/service/blockscanner.js
@@ -152,17 +152,19 @@ function* saveBlockRange(channelName, start, end) {
 
             if (actualPayload) {
                 // Storing of the transaction as new record or update record depends on the transacton body here.
-                var row = yield sql.getRowByPkOne(`select * from uuid where id='${uuid}'`)
-                if (row && row.length > 0){
+                var row = yield sql.getRowByPkOne(`select * from uuid where id='${actualPayload}'`)
+
+                if (row && row.id == actualPayload){
                     // update the UUID row with the response.
+
                     yield sql.updateRow('uuid',
                         {
-                            'id': row.id,
-                            'reqcreatedt': row.reqcreatedt,
-                            'respayload': "Hello", // Something from tx comes here.
-                            'respayload': new Date(tx.payload.header.channel_header.timestamp)
-                        },
-                        "")
+                            'respayload': "Hello",
+                            'rescreatedt': new Date(tx.payload.header.channel_header.timestamp).toISOString()
+                        },{
+                            'id': actualPayload
+                        })
+
                 } else {
                     // create a new row as it is being seen for the first time.
                     yield sql.saveRow('uuid',

--- a/app/service/blockscanner.js
+++ b/app/service/blockscanner.js
@@ -157,13 +157,10 @@ function* saveBlockRange(channelName, start, end) {
                 if (row && row.id == actualPayload){
                     // update the UUID row with the response.
 
-                    yield sql.updateRow('uuid',
-                        {
-                            'respayload': "Hello",
-                            'rescreatedt': new Date(tx.payload.header.channel_header.timestamp).toISOString()
-                        },{
-                            'id': actualPayload
-                        })
+                    var respayload = "Hello"
+                    var rescreatedt = new Date(tx.payload.header.channel_header.timestamp).toISOString()
+
+                    yield sql.updateBySql(`update uuid set respayload='${respayload}', rescreatedt='${rescreatedt}' where id='${actualPayload}' returning *`)
 
                 } else {
                     // create a new row as it is being seen for the first time.

--- a/client/src/components/CountHeader/MenuBar.js
+++ b/client/src/components/CountHeader/MenuBar.js
@@ -82,7 +82,7 @@ class MenuBar extends Component {
     setInterval(() => {
       this.props.getCountHeader(this.props.channel.currentChannel);
       this.props.getLatestBlock(this.props.channel.currentChannel, 0);
-      this.props.getUUIDStatusRow(this.props.channel.currentChannel);
+      this.props.getUUIDStatusList(this.props.channel.currentChannel);
     }, 3000)
 
   }

--- a/client/src/components/CountHeader/MenuBar.js
+++ b/client/src/components/CountHeader/MenuBar.js
@@ -240,7 +240,6 @@ const mapDispatchToProps = (dispatch) => ({
   getUUIDStatusList: (curChannel) => dispatch(getUUIDStatusListCreator(curChannel))
 });
 
-console.log(state);
 const mapStateToProps = state => ({
   block: state.block.block,
   blockList: state.blockList.blockList,

--- a/client/src/components/CountHeader/MenuBar.js
+++ b/client/src/components/CountHeader/MenuBar.js
@@ -12,12 +12,15 @@ import Transactions from '../Lists/Transactions';
 import DashboardView from '../View/DashboardView';
 import Channels from '../Lists/Channels';
 import Chaincodes from '../Lists/Chaincodes';
+import MatchedUUID from '../Lists/MatchedUUID';
 import { getChaincodes as getChaincodesCreator } from '../../store/actions/chaincodes/action-creators';
 import { getBlockList as getBlockListCreator } from '../../store/actions/block/action-creators';
 import { getTransactionInfo as getTransactionInfoCreator } from '../../store/actions/transaction/action-creators';
 import { getLatestBlock as getLatestBlockCreator } from '../../store/actions/latestBlock/action-creators';
 import { getHeaderCount as getCountHeaderCreator } from '../../store/actions/header/action-creators';
 import { getTransactionList as getTransactionListCreator } from '../../store/actions/transactions/action-creators';
+import { getUUIDStatusRow as getUUIDStatusRowCreator } from '../../store/actions/matcheduuid/action-creators';
+import { getUUIDStatusList as getUUIDStatusListCreator } from '../../store/actions/matcheduuids/action-creators';
 
 
 import {
@@ -49,7 +52,7 @@ class MenuBar extends Component {
     super(props);
     this.state = {
       activeView: 'DashboardView',
-      activeTab: { dashboardTab: true, peersTab: false, blocksTab: false, chaincodesTab: false },
+      activeTab: { dashboardTab: true, peersTab: false, blocksTab: false, chaincodesTab: false, matchedUUIDTab: false },
       countHeader: { countHeader: this.props.getCountHeader() }
     }
 
@@ -58,6 +61,7 @@ class MenuBar extends Component {
     this.handleClickChannelView = this.handleClickChannelView.bind(this);
     this.handleClickPeerView = this.handleClickPeerView.bind(this);
     this.handleClickDashboardView = this.handleClickDashboardView.bind(this);
+    this.handleClickMatchedUUIDView = this.handleClickMatchedUUIDView.bind(this);
   }
 
   componentWillMount() {
@@ -77,7 +81,8 @@ class MenuBar extends Component {
 
     setInterval(() => {
       this.props.getCountHeader(this.props.channel.currentChannel);
-      this.props.getLatestBlock(this.props.channel.currentChannel,0);
+      this.props.getLatestBlock(this.props.channel.currentChannel, 0);
+      this.props.getUUIDStatusRow(this.props.channel.currentChannel);
     }, 3000)
 
   }
@@ -93,7 +98,9 @@ class MenuBar extends Component {
         peersTab: false,
         blocksTab: false,
         txTab: true,
-        chaincodesTab: false      }
+        chaincodesTab: false,
+        matchedUUIDTab: false
+      }
     });
   }
   handleClickBlockView() {
@@ -104,7 +111,8 @@ class MenuBar extends Component {
         peersTab: false,
         blocksTab: true,
         txTab: false,
-        chaincodesTab: false
+        chaincodesTab: false,
+        matchedUUIDTab: false
       }
     });
   }
@@ -119,7 +127,8 @@ class MenuBar extends Component {
         peersTab: true,
         blocksTab: false,
         txTab: false,
-        chaincodesTab: false
+        chaincodesTab: false,
+        matchedUUIDTab: false
       }
     });
   }
@@ -131,7 +140,8 @@ class MenuBar extends Component {
         peersTab: false,
         blocksTab: false,
         txTab: false,
-        chaincodesTab: false
+        chaincodesTab: false,
+        matchedUUIDTab: false
       }
     });
   }
@@ -143,7 +153,21 @@ class MenuBar extends Component {
         peersTab: false,
         blocksTab: false,
         txTab: false,
-        chaincodesTab: true
+        chaincodesTab: true,
+        matchedUUIDTab: false
+      }
+    });
+  }
+  handleClickMatchedUUIDView = () => {
+    this.setState({ activeView: 'MatchedUUIDView' });
+    this.setState({
+      activeTab: {
+        dashboardTab: false,
+        peersTab: false,
+        blocksTab: false,
+        txTab: false,
+        chaincodesTab: false,
+        matchedUUIDTab: true
       }
     });
   }
@@ -168,7 +192,10 @@ class MenuBar extends Component {
         currentView = <DashboardView />;
         break;
       case 'ChaincodeView':
-        currentView = <Chaincodes channel={this.props.channel} countHeader={this.props.countHeader} chaincodes={this.props.chaincodes} getChaincodes={this.props.getChaincodes}/>
+        currentView = <Chaincodes channel={this.props.channel} countHeader={this.props.countHeader} chaincodes={this.props.chaincodes} getChaincodes={this.props.getChaincodes}/>;
+        break;
+      case 'MatchedUUIDView':
+        currentView = <MatchedUUID channel={this.props.channel} countHeader={this.props.countHeader} uuidList={this.props.uuidList.rows} getUUIDStatusList={this.props.getUUIDStatusList} uuid={this.props.uuid} getUUIDStatusRow={this.props.getUUIDStatusRow}/>;
         break;
       default:
         currentView = <DashboardView />;
@@ -178,13 +205,14 @@ class MenuBar extends Component {
     return (
       <div>
         <div className="menuItems">
-          <Navbar color="faded" light expand="md">
+          <Navbar color="faded" light expand="md" margin-left="0px">
             <Nav className="ml-auto" navbar>
-              <NavItem active={this.state.activeTab.dashboardTab} onClick={this.handleClickDashboardView}>DASHBOARD </NavItem>
-              <NavItem active={this.state.activeTab.peersTab} onClick={this.handleClickPeerView}>NETWORK  </NavItem>
-              <NavItem active={this.state.activeTab.blocksTab} onClick={this.handleClickBlockView}>BLOCKS </NavItem>
+              <NavItem active={this.state.activeTab.dashboardTab} onClick={this.handleClickDashboardView}>DASHBOARD</NavItem>
+              <NavItem active={this.state.activeTab.peersTab} onClick={this.handleClickPeerView}>NETWORK</NavItem>
+              <NavItem active={this.state.activeTab.blocksTab} onClick={this.handleClickBlockView}>BLOCKS</NavItem>
               <NavItem active={this.state.activeTab.txTab} onClick={this.handleClickTransactionView}>TRANSACTIONS</NavItem>
               <NavItem active={this.state.activeTab.chaincodesTab} onClick={this.handleClickChaincodeView }>CHAINCODES</NavItem>
+              <NavItem active={this.state.activeTab.matchedUUIDTab} onClick={this.handleClickMatchedUUIDView }>UUID</NavItem>
             </Nav>
           </Navbar>
         </div>
@@ -200,17 +228,19 @@ class MenuBar extends Component {
 
 const mapDispatchToProps = (dispatch) => ({
   getLatestBlock: (curChannel) => dispatch(getLatestBlockCreator(curChannel)),
-  getBlockList: (channel,offset) => dispatch(getBlockListCreator(channel,offset)),
-  getChaincodes: (channel,offset) => dispatch(getChaincodesCreator(channel,offset)),
+  getBlockList: (channel, offset) => dispatch(getBlockListCreator(channel, offset)),
+  getChaincodes: (channel, offset) => dispatch(getChaincodesCreator(channel, offset)),
   getChannel: (channel, offset) => null,
   getChannelList: (offset) => null,
   getCountHeader: (curChannel) => dispatch(getCountHeaderCreator(curChannel)),
   getPeerList: (curChannel) => null,
-  getTransactionInfo: (curChannel,tx_id) => dispatch(getTransactionInfoCreator(curChannel,tx_id)),
-  getTransactionList: (curChannel,offset) => dispatch(getTransactionListCreator(curChannel,offset))
+  getTransactionInfo: (curChannel, tx_id) => dispatch(getTransactionInfoCreator(curChannel, tx_id)),
+  getTransactionList: (curChannel, offset) => dispatch(getTransactionListCreator(curChannel, offset)),
+  getUUIDStatusRow: (curChannel) => dispatch(getUUIDStatusRowCreator(curChannel)),
+  getUUIDStatusList: (curChannel) => dispatch(getUUIDStatusListCreator(curChannel))
 });
 
-
+console.log(state);
 const mapStateToProps = state => ({
   block: state.block.block,
   blockList: state.blockList.blockList,
@@ -221,6 +251,8 @@ const mapStateToProps = state => ({
   peerList: state.peerList.peerList,
   transaction: state.transaction.transaction,
   transactionList: state.transactionList.transactionList,
+  uuid: state.uuid.uuid,
+  uuidList: state.uuidList.uuidList
 });
 
 

--- a/client/src/components/Lists/MatchedUUID.js
+++ b/client/src/components/Lists/MatchedUUID.js
@@ -1,0 +1,96 @@
+import React, { Component } from 'react';
+import { Container, Row, Col, TooltTip } from 'reactstrap';
+import ReactTable from 'react-table';
+import 'react-table/react-table.css';
+import matchSorter from 'match-sorter';
+
+class MatchedUUID extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: false,
+            totalBlocks: this.props.countHeader.txCount,
+            dialogOpen: false
+        }
+    }
+
+    convertTime = date => {
+        var hold = new Date(date);
+        var hours = hold.getHours();
+        var minutes = hold.getMinutes();
+        var strTime = hours + ":" + minutes + "GMT";
+        return strTime;
+    }
+
+    handleDialogOpen = tid => {
+        this.props.getTransactionInfo(this.props.channel.currentChannel, tid);
+        this.setState({ dialogOpen: true });
+    }
+
+    handleDialogClose = () => {
+        this.setState({ dialogOpen: false });
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({ totalBlocks: this.props.countHeader.txCount });
+    }
+
+    componentDidMount() {
+
+    }
+
+    render() {
+        const columnHeaders = [
+            {
+                Header: "UUID",
+                accessor: "id",
+                filterMethod: (filter, rows) =>
+                    matchSorter(rows, filter.value, { keys: ["payload"] }, { threshold: matchSorter.rankings.SIMPLEMATCH }),
+                filterAll: true
+            },
+            {
+                Header: "Request Created At",
+                accessor: "reqcreatedt",
+                filterMethod: (filter, rows) =>
+                    matchSorter(rows, filter.value, { keys: ["createdt"] }, { threshold: matchSorter.rankings.SIMPLEMATCH }),
+                filterAll: true
+            },
+            {
+                Header: "Response",
+                accessor: "respayload",
+                filterMethod: (filter, rows) =>
+                    matchSorter(rows, filter.value, { keys: ["payload"] }, { threshold: matchSorter.rankings.SIMPLEMATCH }),
+                filterAll: true
+            },
+            {
+                Header: "Response Created At",
+                accessor: "rescreatedt",
+                filterMethod: (filter, rows) =>
+                    matchSorter(rows, filter.value, { keys: ["createdt"] }, { threshold: matchSorter.rankings.SIMPLEMATCH }),
+                filterAll: true
+            }
+        ];
+
+        return (
+            <div className="blockPage">
+                <Container>
+                    <Row>
+                        <Col>
+                            <div className="scrollTable">
+                                <ReactTable
+                                    data={this.props.uuidList}
+                                    columns={columnHeaders}
+                                    defaultPageSize={10}
+                                    className="-stripped -highlight"
+                                    filterable
+                                />
+                            </div>
+                        </Col>
+                    </Row>
+                </Container>
+            </div>
+        );
+    }
+};
+
+export default MatchedUUID;

--- a/client/src/components/Lists/MatchedUUID.js
+++ b/client/src/components/Lists/MatchedUUID.js
@@ -36,7 +36,9 @@ class MatchedUUID extends Component {
     }
 
     componentDidMount() {
-
+        setInterval(() => {
+            this.props.getUUIDStatusList(this.props.channel.currentChannel);
+        }, 6000)
     }
 
     render() {

--- a/client/src/components/View/TransactionView.js
+++ b/client/src/components/View/TransactionView.js
@@ -54,11 +54,6 @@ class TransactionView extends Component {
         this.setState({ loading: false });
     }
 
-    getUUID(jsonObj) {
-        var obj = JSON.parse(jsonObj);
-        return JSON.parse(jsonObj).uuid;
-    }
-
     render() {
         const { classes } = this.props;
         if (this.props.transaction.read_set === undefined) {
@@ -85,7 +80,7 @@ class TransactionView extends Component {
                             <b>Endorser:</b> {this.props.transaction.endorser_msp_id} <br />
                             <b>Chaincode Name:</b> {this.props.transaction.chaincode_id} <br />
                             <b>Type:</b> {this.props.transaction.type} <br />
-                            <b>Payload:</b> {this.getUUID(this.props.transaction.payload.replace(/\\/g, "").replace("\"{", "{").replace("}\"", "}")) }<br />
+                            <b>Payload:</b> { this.props.transaction.payload }<br />
                             <b>Time:</b> {moment(this.props.transaction.createdt).tz(moment.tz.guess()).format("M-D-YYYY h:mm A zz")} <br />
                             <b>Reads:</b>
                              <ul>

--- a/client/src/store/actions/action-types.js
+++ b/client/src/store/actions/action-types.js
@@ -22,4 +22,5 @@ export const COUNT_HEADER_POST = `${namespaces}/COUNT_HEADER_POST`;
 export const CHAINCODE_LIST = `${namespaces}/CHAINCODE_LIST`;
 export const NOTIFICATION_LOAD = `${namespaces}/NOTIFICATION_LOAD`;
 export const TX_CHART_ORG = `${namespaces}/TX_CHART_ORG`;
-
+export const UUID_LIST = `${namespaces}/UUID_LIST`;
+export const UUID_ROW = `${namespaces}/UUID_ROW`;

--- a/client/src/store/actions/matcheduuid/action-creators.js
+++ b/client/src/store/actions/matcheduuid/action-creators.js
@@ -1,0 +1,12 @@
+import { createAction } from 'redux-actions'
+import * as actionTypes from '../action-types'
+import { get } from '../../../services/request.js';
+
+export const getUUIDStatusRow = (channel) => dispatch => {
+    get('/api/uuid/' + channel)
+        .then(resp => {
+            dispatch(createAction(actionTypes.UUID_ROW)(resp))
+        }).catch((error) => {
+            console.log(error);
+        })
+}

--- a/client/src/store/actions/matcheduuids/action-creators.js
+++ b/client/src/store/actions/matcheduuids/action-creators.js
@@ -1,0 +1,12 @@
+import { createAction } from 'redux-actions'
+import * as actionTypes from '../action-types'
+import { get } from '../../../services/request.js';
+
+export const getUUIDStatusList = (channel) => dispatch => {
+    get('/api/uuidlist/' + channel)
+        .then(resp => {
+            dispatch(createAction(actionTypes.UUID_LIST)(resp))
+        }).catch((error) => {
+            console.log(error);
+        })
+}

--- a/client/src/store/reducers/index.js
+++ b/client/src/store/reducers/index.js
@@ -18,6 +18,8 @@ import txPerHour from './txPerHour';
 import chaincodes from './chaincodes';
 import notification from './notification';
 import txByOrg from './txByOrg';
+import uuid from './uuid';
+import uuidList from './uuidList';
 export default combineReducers({
     peerList,
     channelList,
@@ -33,5 +35,7 @@ export default combineReducers({
     txPerHour,
     chaincodes,
     notification,
-    txByOrg
+    txByOrg,
+    uuid,
+    uuidList
 })

--- a/client/src/store/reducers/uuid.js
+++ b/client/src/store/reducers/uuid.js
@@ -1,6 +1,7 @@
 import { handleActions } from 'redux-actions'
 import { Record } from 'immutable'
 import * as actionTypes from '../actions/action-types'
+import moment from 'moment-timezone'
 
 const InitialState = new Record({
     loaded: false,
@@ -9,10 +10,14 @@ const InitialState = new Record({
 });
 
 const uuid = handleActions({
-    [actionTypes.UUID_ROW]: (state = InitialState(), action) => state
-        .set('loaded', true)
-        .set('uuid', action.payload)
-        .set('errors', action.error)
+    [actionTypes.UUID_ROW]: (state = InitialState(), action) => {
+        return (
+            state
+                .set('loaded', true)
+                .set('uuid', action.payload)
+                .set('errors', action.error)
+        )
+    }
 }, new InitialState());
 
 export default uuid;

--- a/client/src/store/reducers/uuid.js
+++ b/client/src/store/reducers/uuid.js
@@ -1,0 +1,18 @@
+import { handleActions } from 'redux-actions'
+import { Record } from 'immutable'
+import * from actionTypes from '../action/action-types'
+
+const InitialState = new Record({
+    loaded: false,
+    uuid: {},
+    errors: {},
+});
+
+const uuid = handleActions({
+    [actionTypes.UUID_ROW]: (state = InitialState(), action) => state
+        .set('loaded', true)
+        .set('uuid', action.payload)
+        .set('errors', action.error)
+}, new InitialState());
+
+export default uuid;

--- a/client/src/store/reducers/uuid.js
+++ b/client/src/store/reducers/uuid.js
@@ -1,6 +1,6 @@
 import { handleActions } from 'redux-actions'
 import { Record } from 'immutable'
-import * from actionTypes from '../action/action-types'
+import * as actionTypes from '../actions/action-types'
 
 const InitialState = new Record({
     loaded: false,

--- a/client/src/store/reducers/uuidList.js
+++ b/client/src/store/reducers/uuidList.js
@@ -1,6 +1,6 @@
 import { handleActions } from 'redux-actions'
 import { Record } from 'immutable'
-import * from actionTypes from '../actions/action-types'
+import * as actionTypes from '../actions/action-types'
 import moment from 'moment-timezone';
 
 const InitialState = new Record ({
@@ -10,7 +10,7 @@ const InitialState = new Record ({
 
 })
 
-const uuidList = handlActions({
+const uuidList = handleActions({
     [actionTypes.UUID_LIST]: (state = InitialState(), action) => {
         action.payload.rows.forEach(element => {
             element.reqcreatedt = moment(element.reqcreatedt).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm")

--- a/client/src/store/reducers/uuidList.js
+++ b/client/src/store/reducers/uuidList.js
@@ -7,13 +7,13 @@ const InitialState = new Record ({
     loaded: false,
     uuidList: [],
     errors: {},
-
 })
 
 const uuidList = handleActions({
     [actionTypes.UUID_LIST]: (state = InitialState(), action) => {
         action.payload.rows.forEach(element => {
             element.reqcreatedt = moment(element.reqcreatedt).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm")
+            element.rescreatedt = moment(element.rescreatedt).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm")
         })
         return (
             state

--- a/client/src/store/reducers/uuidList.js
+++ b/client/src/store/reducers/uuidList.js
@@ -1,0 +1,27 @@
+import { handleActions } from 'redux-actions'
+import { Record } from 'immutable'
+import * from actionTypes from '../actions/action-types'
+import moment from 'moment-timezone';
+
+const InitialState = new Record ({
+    loaded: false,
+    uuidList: [],
+    errors: {},
+
+})
+
+const uuidList = handlActions({
+    [actionTypes.UUID_LIST]: (state = InitialState(), action) => {
+        action.payload.rows.forEach(element => {
+            element.reqcreatedt = moment(element.reqcreatedt).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm")
+        })
+        return (
+            state
+                .set('uuidList', action.payload)
+                .set('loaded', true)
+                .set('errors', action.error)
+        )
+    }
+}, new InitialState());
+
+export default uuidList;

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ var requtil = require('./app/utils/requestutils.js')
 var logger = helper.getLogger('main');
 var txModel = require('./app/models/transactions.js')
 var blocksModel = require('./app/models/blocks.js')
+var uuidModel = require('./app/models/uuids.js')
 var configuration = require('./app/FabricConfiguration.js')
 var url = require('url');
 var WebSocket = require('ws');
@@ -450,6 +451,44 @@ app.get("/api/txByOrg/:channel", function (req, res) {
         return requtil.invalidRequest(req, res)
     }
 });
+
+/***
+UUIDs List requested and responded back with.
+GET /api/uuidlist/<channel>
+curl -i 'http://<host>:<port>//api/uuidlist/<channel>'
+Response:
+{"rows":[{"id":"4abc","reqcreatedt":"2018-05-31 12:00", "respayload":"Yes", "rescreatedt":"2018-05-31 12:00"}]}
+
+*/
+
+app.get("/api/uuidlist/:channel", function (req, res) {
+
+    let channelName = req.params.channel;
+    if (channelName) {
+        uuidModel.getUUIDStatusList(channelName)
+            .then(rows => {
+                if (rows) {
+                    return res.send({ status: 200, rows: rows })
+                }
+            })
+    } else {
+        return requtil.invalidRequest(req, res)
+    }
+});
+
+app.get("/api/uuid/:channel", function (req, res) {
+    let channelName = req.params.channel;
+
+    if(channelName) {
+        uuidModel.getUUIDStatusRow(channelName)
+            .then(row => {
+                if (row) {
+                    return res.send({ status: 200, row: row })
+                }
+            })
+    }
+})
+
 /***
     An API to create a channel
 POST /api/channel


### PR DESCRIPTION
### Ref:
#29 

### Description:
The main task was to create a page in the explorer to include the information about the incoming and outgoing UUIDs and their response objects that was sent. This will allow to know how many responses were sent and how many responses were matched.

### Blocking:
Nah

### Documentation:
There are mainly four fields to understand here:
1. The UUID of the request.
1. The timestamp when the request arrived to the provider.
1. The response sent to the consumer after the matching protocol finishes.
1. The timestamp when the response was sent.

### Testing:
Test as usual, by using the command: `npm start`