### PR TITLE
Update Docker documentation

### DIFF
--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -1,0 +1,23 @@
+FROM node:6
+
+RUN mkdir -p /opt/gopath/src/github.com/distributedID
+
+ARG REACT_APP_CLIENT=Provider
+ENV REACT_APP_CLIENT=$REACT_APP_CLIENT
+ENV GOPATH=/opt/gopath
+
+WORKDIR /opt/gopath/src/github.com/distributedID
+
+ADD . /opt/gopath/src/github.com/distributedID/blockchain-explorer
+
+WORKDIR /opt/gopath/src/github.com/distributedID/blockchain-explorer
+
+ADD ./config-$REACT_APP_CLIENT.json ./config.json
+
+RUN npm install && \
+	cd client && \
+	npm install && \
+	REACT_APP_CLIENT=$REACT_APP_CLIENT npm run build
+
+
+EXPOSE 11000

--- a/README.md
+++ b/README.md
@@ -48,27 +48,25 @@ git clone https://github.com/distributedID/blockchain-explorer
 cd blockchain-explorer
 ```
 
-## Building the required Docker Images
+## Building Docker Images
 
-We need to build two images to properly use the `explorer`:
-
-1. Build the postgres image, located at `distributedid/postgres`. To build this image enter the following command:
+You can build all the necessary Docker images from the `bcmanager` project:
 
 ```
-bcmanager$ docker build -t distributedid/postgres-consumer -f ./docker/Dockerfile.postgres .
+make buildDockerImages
 ```
 
-2.  Build the explorer image, located at `distributedid/explorer`. To build this image enter the following command:
+To build an image using local changes from the `blockchain-explorer` project:
 
 ```
-bcmanager$ docker build --build-arg REACT_APP_CLIENT=Provider -t distributedid/explorer-provider -f ./docker/Dockerfile.explorer .
+docker build --build-arg REACT_APP_CLIENT=Provider -t distributedid/explorer-provider -f ./docker/Dockerfile.provider-explorer .
 ```
 ```
-bcmanager$ docker build --build-arg REACT_APP_CLIENT=Consumer -t distributedid/explorer-consumer -f ./docker/Dockerfile.explorer .
+docker build --build-arg REACT_APP_CLIENT=Consumer -t distributedid/explorer-consumer -f ./docker/Dockerfile.consumer-explorer .
 
 ```
 
-## How to start it?
+## Starting blockchain-explorer
 
 Steps:
 
@@ -78,114 +76,54 @@ Note: Run within the __bcmanager__ repository
 
 1. To run the `diid.network`. Enter the commands separately:
 
-```
-bcmanager$ make startEnv
-```
-```
-bcmanager$ make initExchChannel initPrivChannel
-```
-```
-bcmanager$ make sendIdentity sendEvent
-```
-```
-bcmanager$ make queryID
-```
+   ```
+   bcmanager$ make startNetwork initChannels
+   bcmanager$ make startRestApi startIdentityWriter
+   bcmanager$ make sendIdentity sendEvent
+   bcmanager$ (cd fixtures/environments/local ; docker-compose up -d postgres-provider postgres-consumer)
+   ```
+
+If all these commands are successful, you will have a Network running in docker with:
+
+- two initialized channels
+- services running to write identities and events
+- Postgres services running for `blockchain-explorer`
 
 ### Window 2:
 
-Note: Open a new window and run in the __bcmanager__ repository
+Note: Open a new window and run in the __bcmanager__ repository.
 
-1. Navigate to the root directory of the `postgres` image by entering:
-(This will take you to the root of the `docker-compose.yml` file, which contains the docker-compose file)
+1. To start the Explorer services in the Network using your local Docker image: 
 
-```
-cd /github.com/distributedID/bcmanager/docker/explorer
-```
-
-2. Use the command to launch the `postgres` image (only for the Provider):
-
-```
-bcmanager/docker/explorer$ docker-compose up postgres-provider.diid.network
-```
-
-### Window 3:
-
-Note: Open a new window and run within the __blockchain-explorer__ repository. These install commands must be run when a new branch is started or a navigated to.
-
-1. Install the required packages in the blockchain-explorer repository. By executing the following commands:
-
-```
-blockchain-explorer$ npm install
-```
-```
-blockchain-explorer/client$ npm install
-```
-
-### Window 4:
-
-Note: Open a new window and run within the __blockchain-explorer__ repository
-
-1. Use the following commands to launch the `explorer` network:
-
-Note: To launch and view `Provider` UI run command:
-```
-blockchain-explorer/client$ REACT_APP_CLIENT=Producer npm run build
-```
-Note: To launch and view `Consumer` UI run command:
-```
-blockchain-explorer/client$ REACT_APP_CLIENT=Consumer npm run build
-```
-
-```
-blockchain-explorer$ npm start
-```
-
-
-2. The `blockchain-explorer` runs with the `Provider` as default. To run it as a consumer, one can change the `config.json`'s `client` configuration to:
-```
-{
-	...
-	"client": "Consumer"
-	...
-}
-```
-
-Note: If editing the source code, the two commands above must be re-run to compile any changes made. If this is not done the explorer will not display any changes!
+   ```
+   bcmanager $ make startExplorer
+   ```
+   
+   Note: If editing the source code, you'll need to rebuild the Docker images in
+   `blockchain-explorer` and restart the Explorer services.
 
 ### Access the GUI
 
-1. Open the web-browser and access the `explorer` at `http://localhost:11000` .
+1. Open the web-browser and access the Provider Explorer at `http://localhost:11000`.
+2. Open the Consumer Provider at `https://localhost:11001`.
 
 
 ## How to stop it?
 
-Note: In the last window where the `explorer` network was started.
-
-1. Tear down the network by entering the following command:
-```
-blockchain-explorer$ ^C (Ctrl-C)
-```
-
-Note: In the window where the `postgres` image was built.
-
-2. Tear down the image by entering the following command:
+To stop the explorer:
 
 ```
-bcmanager/docker/explorer$ ^C (Ctrl-C)
-```
-```
-bcmanager/docker/explorer$ docker-compose down
+bcmanager $ make stopExplorer
 ```
 
-Note: In the first window where the `diid.network` network was ran.
-
-3. Tear down the network by entering:
-
+To tear down the network and start over:
 ```
 bcmanager$ make stopEnv
 ```
 
-Note: These commands need to be preformed to properly tear down the networks so that they can be built in the future. Many problems can occur if these commands are not preformed.
+Note: These commands need to be preformed to properly tear down the networks so
+that they can be built in the future. Many problems can occur if these commands
+are not preformed.
 
 
 ## Troubleshooting:

--- a/README.md
+++ b/README.md
@@ -93,14 +93,27 @@ If all these commands are successful, you will have a Network running in docker 
 
 Note: Open a new window and run in the __bcmanager__ repository.
 
-1. To start the Explorer services in the Network using your local Docker image: 
+1. To start the Explorer services in the Network using a Docker image:
 
    ```
    bcmanager $ make startExplorer
    ```
-   
+
    Note: If editing the source code, you'll need to rebuild the Docker images in
    `blockchain-explorer` and restart the Explorer services.
+
+2. Or, to start the Explorer on your computer:
+
+   ```
+   # if a new branch or dependencies have changed
+   blockchain-explorerer$ npm install
+   blockchain-explorerer$ (cd client ; npm install )
+
+   blockchain-explorerer$ (cd client ; REACT_APP_CLIENT=Producer npm run build )
+   # or
+   blockchain-explorerer$ (cd client ; REACT_APP_CLIENT=Consumer npm run build )
+   blockchain-explorerer$ npm start
+   ```
 
 ### Access the GUI
 

--- a/config-Consumer.json
+++ b/config-Consumer.json
@@ -1,0 +1,64 @@
+{
+	"network-config": {
+		"org0": {
+			"name": "Org0",
+			"mspid": "Org0MSP",
+			"peer0": {
+				"requests": "grpcs://peer0.org0.diid.network:7051",
+				"events": "grpcs://peer0.org0.diid.network:7053",
+				"server-hostname": "peer0.org0.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org0.diid.network/peers/peer0.org0.diid.network/tls/ca.crt"
+			},
+			"peer1": {
+				"requests": "grpcs://peer1.org0.diid.network:7051",
+				"events": "grpcs://peer1.org0.diid.network:7053",
+				"server-hostname": "peer1.org0.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org0.diid.network/peers/peer1.org0.diid.network/tls/ca.crt"
+			},
+			"admin": {
+				"key": "/opt/crypto-config/peerOrganizations/org0.diid.network/users/Admin@org0.diid.network/msp/keystore",
+				"cert": "/opt/crypto-config/peerOrganizations/org0.diid.network/users/Admin@org0.diid.network/msp/signcerts"
+			}
+		},
+		"org1": {
+			"name": "Org1",
+			"mspid": "Org1MSP",
+			"peer0": {
+				"requests": "grpcs://peer0.org1.diid.network:7051",
+				"events": "grpcs://peer0.org1.diid.network:7053",
+				"server-hostname": "peer0.org1.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org1.diid.network/peers/peer0.org1.diid.network/tls/ca.crt"
+			},
+			"peer1": {
+				"requests": "grpcs://peer1.org1.diid.network:7051",
+				"events": "grpcs://peer1.org1.diid.network:7053",
+				"server-hostname": "peer1.org1.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org1.diid.network/peers/peer1.org1.diid.network/tls/ca.crt"
+			},
+			"admin": {
+				"key": "/opt/crypto-config/peerOrganizations/org1.diid.network/users/Admin@org1.diid.network/msp/keystore",
+				"cert": "/opt/crypto-config/peerOrganizations/org1.diid.network/users/Admin@org1.diid.network/msp/signcerts"
+			}
+		}
+	},
+	"host": "0.0.0.0",
+	"port": "11000",
+	"channel": "exchange-channel",
+	"client": "Consumer",
+	"keyValueStore": "/tmp/fabric-client-kvs",
+	"eventWaitTime": "30000",
+	"users":[
+		{
+		   "username":"admin",
+		   "secret":"adminpw"
+		}
+	 ],
+	"pg": {
+		"host": "postgres-consumer.diid.network",
+		"port": "5432",
+		"database": "fabricexplorer",
+		"username": "diid",
+		"passwd": "diid-diid"
+	},
+	"license": "Apache-2.0"
+}

--- a/config-Provider.json
+++ b/config-Provider.json
@@ -1,0 +1,64 @@
+{
+	"network-config": {
+		"org0": {
+			"name": "Org0",
+			"mspid": "Org0MSP",
+			"peer0": {
+				"requests": "grpcs://peer0.org0.diid.network:7051",
+				"events": "grpcs://peer0.org0.diid.network:7053",
+				"server-hostname": "peer0.org0.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org0.diid.network/peers/peer0.org0.diid.network/tls/ca.crt"
+			},
+			"peer1": {
+				"requests": "grpcs://peer1.org0.diid.network:7051",
+				"events": "grpcs://peer1.org0.diid.network:7053",
+				"server-hostname": "peer1.org0.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org0.diid.network/peers/peer1.org0.diid.network/tls/ca.crt"
+			},
+			"admin": {
+				"key": "/opt/crypto-config/peerOrganizations/org0.diid.network/users/Admin@org0.diid.network/msp/keystore",
+				"cert": "/opt/crypto-config/peerOrganizations/org0.diid.network/users/Admin@org0.diid.network/msp/signcerts"
+			}
+		},
+		"org1": {
+			"name": "Org1",
+			"mspid": "Org1MSP",
+			"peer0": {
+				"requests": "grpcs://peer0.org1.diid.network:7051",
+				"events": "grpcs://peer0.org1.diid.network:7053",
+				"server-hostname": "peer0.org1.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org1.diid.network/peers/peer0.org1.diid.network/tls/ca.crt"
+			},
+			"peer1": {
+				"requests": "grpcs://peer1.org1.diid.network:7051",
+				"events": "grpcs://peer1.org1.diid.network:7053",
+				"server-hostname": "peer1.org1.diid.network",
+				"tls_cacerts": "/opt/crypto-config/peerOrganizations/org1.diid.network/peers/peer1.org1.diid.network/tls/ca.crt"
+			},
+			"admin": {
+				"key": "/opt/crypto-config/peerOrganizations/org1.diid.network/users/Admin@org1.diid.network/msp/keystore",
+				"cert": "/opt/crypto-config/peerOrganizations/org1.diid.network/users/Admin@org1.diid.network/msp/signcerts"
+			}
+		}
+	},
+	"host": "0.0.0.0",
+	"port": "11000",
+	"channel": "exchange-channel",
+	"client": "Provider",
+	"keyValueStore": "/tmp/fabric-client-kvs",
+	"eventWaitTime": "30000",
+	"users":[
+		{
+		   "username":"admin",
+		   "secret":"adminpw"
+		}
+	 ],
+	"pg": {
+		"host": "postgres-provider.diid.network",
+		"port": "5432",
+		"database": "fabricexplorer",
+		"username": "diid",
+		"passwd": "diid-diid"
+	},
+	"license": "Apache-2.0"
+}


### PR DESCRIPTION
This change updates the documentation to try to explain how to use the Docker Development Network with the Explorer. It also adds some files to build a Docker image from this repo. I think, eventually, all the Docker stuff in `bcmanager` for the Explorer should be moved to this repo.

You can see the rendered output here: https://github.com/distributedID/blockchain-explorer/blob/update-docs/README.md

I'm not quite sure this totally works or if it addresses all the use cases, so any feedback is Generously Welcomed. 🤗 